### PR TITLE
write namespace for starts_with, ends_with

### DIFF
--- a/lib/text/string_ex.fix
+++ b/lib/text/string_ex.fix
@@ -208,7 +208,7 @@ _append_range = |src_arr, src_begin, src_end, dest_arr| (
 // ```
 replace_suffix: String -> String -> String -> Result ErrMsg String;
 replace_suffix = |from, to, str| (
-    if !str.ends_with(from) {
+    if !str.StringEx::ends_with(from) {
         err $ "suffix does not match: " + str
     };
     let str = str.substring(0, str.get_size - from.get_size);

--- a/tests/text/string_ex_test.fix
+++ b/tests/text/string_ex_test.fix
@@ -265,7 +265,7 @@ test_starts_with_ok: (String, String, Bool) -> TestCase;
 test_starts_with_ok = |(str, prefix, expected)| (
     let testname = "test_starts_with_ok (" + str + "," + prefix + "," + expected.to_string + ")";
     make_test(testname) $ |_|
-    let actual = str.starts_with(prefix);
+    let actual = str.StringEx::starts_with(prefix);
     assert_equal("eq", expected, actual);;
     pure()
 );
@@ -296,7 +296,7 @@ test_ends_with_ok: (String, String, Bool) -> TestCase;
 test_ends_with_ok = |(str, prefix, expected)| (
     let testname = "test_ends_with_ok (" + str + "," + prefix + "," + expected.to_string + ")";
     make_test(testname) $ |_|
-    let actual = str.ends_with(prefix);
+    let actual = str.StringEx::ends_with(prefix);
     assert_equal("eq", expected, actual);;
     pure()
 );


### PR DESCRIPTION
Stdにstarts_with, ends_withが追加されたことに対する対応です。